### PR TITLE
CN server: use local switches for installation instructions and in CI

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -31,34 +31,36 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
+      - name: Link lockfile
+        working-directory: cn-lsp/server
+        run: ln -s cnlsp.opam.locked-${{ matrix.ocaml-version }} cnlsp.opam.locked
+
       - name: Restore `_opam`
         id: cache-opam-restore
         uses: actions/cache/restore@v4
         with:
-          path: _opam
-          key: ${{ matrix.ocaml-version }}
+          path: cn-lsp/server/_opam
+          key: ${{ matrix.ocaml-version }}-${{ hashFiles('cn-lsp/server/cnlsp.opam.locked') }}
 
       - name: Install server dependencies
-        working-directory: ./cn-lsp/server
-        run: |
-          eval $(opam env)
-          opam install . --deps-only --locked -y
+        working-directory: cn-lsp/server
+        # If we restored a `_opam` directory here, we need not (and should not)
+        # try to create a switch. The presence of `_opam` seems basically
+        # isomorphic to the presence of a switch, and opam will fail to `create`
+        # a new switch if one is already present.
+        run: ls _opam || opam switch create . ocaml.${{ matrix.ocaml-version }} --deps-only --locked -y
 
       - name: Cache `_opam`
         if: steps.cache-opam-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: _opam
+          path: cn-lsp/server/_opam
           key: ${{ steps.cache-opam-restore.outputs.cache-primary-key }}
 
       - name: Build server
-        working-directory: ./cn-lsp/server
-        run: |
-          eval $(opam env)
-          dune build
+        working-directory: cn-lsp/server
+        run: eval $(opam env) && dune build
 
       - name: Run server tests
-        working-directory: ./cn-lsp/server
-        run: |
-          eval $(opam env)
-          dune test
+        working-directory: cn-lsp/server
+        run: eval $(opam env) && dune test

--- a/cn-lsp/client/README.md
+++ b/cn-lsp/client/README.md
@@ -31,8 +31,10 @@ the last step from VSCode's GUI:
 
 Running CN requires that the client be able to find and run a CN language
 server. [Our server's README](../server/README.md) has instructions for a basic
-installation. If you want to control the exact server the client uses, these are
-the locations the client will search (in order) for a server executable:
+installation. In the client, you'll be prompted to select the opam switch you
+created for the server. Your choice is preserved on a per-workspace basis, and
+can be changed by editing your workspace settings. If you don't choose, the
+client will search these locations (in order) for a server executable:
 - The `CN_LSP_SERVER` environment variable
 - On the current `PATH`, for an executable named `cn-lsp-server`
 

--- a/cn-lsp/client/package-lock.json
+++ b/cn-lsp/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cn-client",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cn-client",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "dependencies": {
                 "vscode-languageclient": "^9.0.1"
             },

--- a/cn-lsp/client/package.json
+++ b/cn-lsp/client/package.json
@@ -34,10 +34,20 @@
         "configuration": {
             "title": "CN",
             "properties": {
+                "CN.cerbRuntime": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Location of Cerberus runtime files"
+                },
                 "CN.runOnSave": {
                     "type": "boolean",
                     "default": false,
                     "description": "Run CN whenever a file is saved"
+                },
+                "CN.serverPath": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Location of the LSP server"
                 }
             }
         },

--- a/cn-lsp/client/package.json
+++ b/cn-lsp/client/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/GaloisInc/VERSE-Toolchain",
         "type": "git"
     },
-    "version": "0.0.3",
+    "version": "0.0.4",
     "engines": {
         "vscode": "^1.75.0"
     },

--- a/cn-lsp/client/src/extension.ts
+++ b/cn-lsp/client/src/extension.ts
@@ -159,7 +159,14 @@ function getConfiguredServerContext(): Maybe<ServerContext> {
 
     // In practice, despite the type annotations, `conf.get` seems capable of
     // returning `null` values, so we need to check them
-    if (serverPath !== null && serverPath !== undefined) {
+    if (
+        serverPath !== null &&
+        serverPath !== undefined &&
+        serverPath !== "" &&
+        cerbRuntime !== null &&
+        cerbRuntime !== undefined &&
+        cerbRuntime !== ""
+    ) {
         return { serverPath, cerbRuntime };
     } else {
         return undefined;

--- a/cn-lsp/server/README.md
+++ b/cn-lsp/server/README.md
@@ -1,48 +1,25 @@
 # Building and Installing
 
 Begin by installing OCaml and opam, if need be - here are
-[instructions](https://ocaml.org/docs/installing-ocaml) for how to do so. CN and
-Cerberus currently recommend, and build with, OCaml 4.14.1, and that version was
-used to generate the lockfile which this installation process relies on. (I've
-also been able to work with other versions as recent as 5.1.1, but your mileage
-may vary.)
+[instructions](https://ocaml.org/docs/installing-ocaml) for how to do so. This
+build process has been tested with OCaml 4.14.1 and 5.1.1, though other versions
+are likely to work as well.
 
-I recommend creating and using an opam switch to maintain an isolated dependency
-installation and development environment:
+With a choice of version in hand, the easiest way to build this package is with
+a local opam switch, like so:
 ```sh
-opam switch create <switch-name> ocaml.4.14.1
-eval $(opam env --switch=<switch-name> --set-switch)
+VERSION=4.14.1  # or 5.1.1
+ln -s cnlsp.opam.locked-$VERSION cnlsp.opam.locked
+opam switch create . ocaml.$VERSION --locked -y
+eval $(opam env)
 ```
 
-Next, you need to install this project's dependencies. This project depends on
-`cerberus`, `cerberus-lib`, and `cn`, which it will fetch and build from a
-particular commit to their repository. However, if you have previously built
- and/or installed `cn` locally, you may need to uninstall it before installing
-this project's dependencies, or else your existing version may shadow the
-version you're trying to install.
+If this command succeeds, it should put a `cn-lsp-server` binary on your
+`$PATH`, but (because the switch is local) only when you're in this directory. I
+recommend choosing a location that's always available on your `$PATH` and either
+copying `cn-lsp-server` to that location or symlinking to it:
 ```sh
-dune uninstall cn
-opam remove cn
+cp `which cn-lsp-server` /somewhere/on/PATH
+# or
+ln -s `which cn-lsp-server` /somewhere/on/PATH
 ```
-
-Now, install this project's dependencies:
-```sh
-opam install . --deps-only --locked -y
-```
-
-Now, you can build and install the project:
-```sh
-dune build
-(cd bin && dune build)
-dune install
-```
-
-Assuming you're using a switch, this will install a `cn-lsp-server` into
-`$OPAM_SWITCH_PREFIX/bin`. I recommend manually expanding
-`$OPAM_SWITCH_PREFIX/bin` and adding it to your `$PATH` in e.g. `.zshrc`, since
-that's the easiest way for a client to locate a server binary. (The earlier
-`opam env` command will have done this, but only for your current shell.)
-
-If you're not using a switch, you'll need to say `dune install --bindir=$(pwd)`
-instead, which will install a `cn-lsp-server` binary into the current directory.
-You should still ensure the binary is available on your `$PATH`.

--- a/cn-lsp/server/README.md
+++ b/cn-lsp/server/README.md
@@ -14,12 +14,8 @@ opam switch create . ocaml.$VERSION --locked -y
 eval $(opam env)
 ```
 
-If this command succeeds, it should put a `cn-lsp-server` binary on your
-`$PATH`, but (because the switch is local) only when you're in this directory. I
-recommend choosing a location that's always available on your `$PATH` and either
-copying `cn-lsp-server` to that location or symlinking to it:
-```sh
-cp `which cn-lsp-server` /somewhere/on/PATH
-# or
-ln -s `which cn-lsp-server` /somewhere/on/PATH
-```
+If this command succeeds, it should install the server into your local switch.
+Any clients should run the binary from there. If a client is run outside the
+context of your local switch, it will also need to set `$CERB_RUNTIME` to point
+to Cerberus's runtime file dependencies, which are (currently) installed in the
+switch at `<opam-dir>/lib/cerberus/runtime`.

--- a/cn-lsp/server/cnlsp.opam.locked-4.14.1
+++ b/cn-lsp/server/cnlsp.opam.locked-4.14.1
@@ -1,0 +1,95 @@
+opam-version: "2.0"
+name: "cnlsp"
+version: "dev"
+synopsis: "CN Language Server"
+description: "A language server protocol implementation for the CN language"
+maintainer: "Sam Cowger"
+authors: "Sam Cowger"
+depends: [
+  "base" {= "v0.16.3"}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "cerberus" {= "b9daa22"}
+  "cerberus-lib" {= "b9daa22"}
+  "cmdliner" {= "1.3.0"}
+  "cn" {= "b9daa22"}
+  "conf-bash" {= "1"}
+  "conf-findutils" {= "1"}
+  "conf-gmp" {= "4"}
+  "conf-pkg-config" {= "3"}
+  "cppo" {= "1.7.0"}
+  "csexp" {= "1.5.2"}
+  "dune" {= "3.16.1"}
+  "dune-configurator" {= "3.16.1"}
+  "jsonrpc" {= "1.17.0"}
+  "lem" {= "2022-12-10"}
+  "linol" {= "0.6"}
+  "linol-lwt" {= "0.6"}
+  "logs" {= "0.7.0"}
+  "lsp" {= "1.17.0"}
+  "lwt" {= "5.8.0"}
+  "menhir" {= "20240715"}
+  "menhirCST" {= "20240715"}
+  "menhirLib" {= "20240715"}
+  "menhirSdk" {= "20240715"}
+  "monomorphic" {= "2.1.0"}
+  "num" {= "1.5-1"}
+  "ocaml" {= "4.14.1"}
+  "ocaml-base-compiler" {= "4.14.1"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocaml-config" {= "2"}
+  "ocaml-options-vanilla" {= "1"}
+  "ocamlbuild" {= "0.15.0"}
+  "ocamlfind" {= "1.9.6"}
+  "ocamlgraph" {= "2.1.0"}
+  "ocplib-endian" {= "1.2"}
+  "parsexp" {= "v0.16.0"}
+  "pprint" {= "20230830"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppx_deriving" {= "6.0.3"}
+  "ppx_deriving_yojson" {= "3.9.0"}
+  "ppx_sexp_conv" {= "v0.16.0"}
+  "ppx_yojson_conv_lib" {= "v0.16.0"}
+  "ppxlib" {= "0.33.0"}
+  "result" {= "1.5"}
+  "seq" {= "base"}
+  "sexplib" {= "v0.16.0"}
+  "sexplib0" {= "v0.16.0"}
+  "sha" {= "1.15.4"}
+  "stdlib-shims" {= "0.3.0"}
+  "topkg" {= "1.0.7"}
+  "trace" {= "0.8"}
+  "uutf" {= "1.0.3"}
+  "yojson" {= "2.2.2"}
+  "zarith" {= "1.14"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+pin-depends: [
+  [
+    "cerberus.b9daa22"
+    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+  ]
+  [
+    "cerberus-lib.b9daa22"
+    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+  ]
+  [
+    "cn.b9daa22"
+    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+  ]
+]

--- a/cn-lsp/server/cnlsp.opam.locked-5.1.1
+++ b/cn-lsp/server/cnlsp.opam.locked-5.1.1
@@ -1,71 +1,71 @@
 opam-version: "2.0"
 name: "cnlsp"
-version: "~dev"
+version: "dev"
 synopsis: "CN Language Server"
 description: "A language server protocol implementation for the CN language"
 maintainer: "Sam Cowger"
 authors: "Sam Cowger"
 depends: [
-  "base" {= "v0.16.3"}
+  "base" {= "v0.17.1"}
   "base-bigarray" {= "base"}
   "base-bytes" {= "base"}
+  "base-domains" {= "base"}
+  "base-nnp" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "cerberus" {= "b9daa22"}
   "cerberus-lib" {= "b9daa22"}
   "cmdliner" {= "1.3.0"}
   "cn" {= "b9daa22"}
-  "conf-bash" {= "1"}
-  "conf-c++" {= "1.0"}
   "conf-findutils" {= "1"}
   "conf-gmp" {= "4"}
   "conf-pkg-config" {= "3"}
-  "conf-python-3" {= "9.0.0"}
-  "cppo" {= "1.6.9"}
+  "cppo" {= "1.7.0"}
   "csexp" {= "1.5.2"}
-  "dune" {= "3.16.0"}
-  "dune-configurator" {= "3.16.0"}
-  "fmt" {= "0.9.0"}
+  "dune" {= "3.16.1"}
+  "dune-configurator" {= "3.16.1"}
   "jsonrpc" {= "1.17.0"}
   "lem" {= "2022-12-10"}
   "linol" {= "0.6"}
   "linol-lwt" {= "0.6"}
   "logs" {= "0.7.0"}
   "lsp" {= "1.17.0"}
-  "lwt" {= "5.7.0"}
+  "lwt" {= "5.8.0"}
   "menhir" {= "20240715"}
   "menhirCST" {= "20240715"}
   "menhirLib" {= "20240715"}
   "menhirSdk" {= "20240715"}
   "monomorphic" {= "2.1.0"}
   "num" {= "1.5-1"}
-  "ocaml" {= "4.14.1"}
-  "ocaml-base-compiler" {= "4.14.1"}
+  "ocaml" {= "5.1.1"}
+  "ocaml-base-compiler" {= "5.1.1"}
   "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocaml-config" {= "2"}
+  "ocaml-config" {= "3"}
   "ocaml-options-vanilla" {= "1"}
+  "ocaml_intrinsics_kernel" {= "v0.17.1"}
   "ocamlbuild" {= "0.15.0"}
   "ocamlfind" {= "1.9.6"}
   "ocamlgraph" {= "2.1.0"}
   "ocplib-endian" {= "1.2"}
-  "parsexp" {= "v0.16.0"}
+  "parsexp" {= "v0.17.0"}
   "pprint" {= "20230830"}
   "ppx_derivers" {= "1.2.1"}
-  "ppx_deriving" {= "6.0.2"}
-  "ppx_sexp_conv" {= "v0.16.0"}
-  "ppx_yojson_conv_lib" {= "v0.16.0"}
-  "ppxlib" {= "0.32.1"}
+  "ppx_deriving" {= "6.0.3"}
+  "ppx_deriving_yojson" {= "3.9.0"}
+  "ppx_sexp_conv" {= "v0.17.0"}
+  "ppx_yojson_conv_lib" {= "v0.17.0"}
+  "ppxlib" {= "0.33.0"}
+  "ppxlib_jane" {= "v0.17.0"}
   "result" {= "1.5"}
   "seq" {= "base"}
-  "sexplib" {= "v0.16.0"}
-  "sexplib0" {= "v0.16.0"}
+  "sexplib" {= "v0.17.0"}
+  "sexplib0" {= "v0.17.0"}
   "sha" {= "1.15.4"}
   "stdlib-shims" {= "0.3.0"}
   "topkg" {= "1.0.7"}
-  "trace" {= "0.7"}
+  "trace" {= "0.8"}
   "uutf" {= "1.0.3"}
   "yojson" {= "2.2.2"}
-  "z3" {= "4.13.0-3"}
   "zarith" {= "1.14"}
 ]
 build: [


### PR DESCRIPTION
Using switches makes the process a bit less fiddly and error-prone, and should obviate some of the stale dependency issues the previous process entailed.