### PR TITLE
client, server: record basic telemetry events

### DIFF
--- a/cn-client/README.md
+++ b/cn-client/README.md
@@ -58,3 +58,14 @@ may end up with a number of orphaned CN processes.
 If the server fails to run CN or interpret its output, you can open up the
 "Output" pane (Cmd-Shift-U) and select "CN" from the dropdown menu on the right
 to see what output CN is producing and why the server is having trouble.
+
+
+# Collecting Telemetry
+
+Our CN language server supports optional collection of user telemetry, to
+support improvements to the tool's usability. Collection is disabled by default.
+
+To enable telemetry collection, go to the settings page for this extension and
+provide a location in which you'd like telemetry to be stored. Changes to this
+setting, whether to enable or disable collection or to change the storage
+destination, will only take effect on the server's start/restart.

--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -48,6 +48,11 @@
                     "type": "string",
                     "default": null,
                     "description": "Location of the LSP server"
+                },
+                "CN.telemetryDir": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Where to store telemetry. Changes take effect on server start/restart."
                 }
             }
         },

--- a/cn-lsp.opam
+++ b/cn-lsp.opam
@@ -16,6 +16,7 @@ depends: [
   "linol-lwt" {>= "0.6" & < "1.0"}
   "logs" {>= "0.7.0" & < "1.0.0"}
   "lsp" {>= "1.17.0" & < "2.0.0"}
+  "telemetry"
   "odoc" {with-doc}
 ]
 build: [

--- a/cn-lsp/lib/dune
+++ b/cn-lsp/lib/dune
@@ -1,6 +1,15 @@
 (library
  (name cnlsp)
- (libraries base cn linol linol-lwt lsp telemetry))
+ (libraries
+  base
+  cn
+  linol
+  linol-lwt
+  lsp
+  ppx_deriving_yojson.runtime
+  telemetry)
+ (preprocess
+  (pps ppx_deriving_yojson)))
 
 (env
  (dev

--- a/cn-lsp/lib/dune
+++ b/cn-lsp/lib/dune
@@ -9,7 +9,7 @@
   ppx_deriving_yojson.runtime
   telemetry)
  (preprocess
-  (pps ppx_deriving_yojson)))
+  (pps ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson)))
 
 (env
  (dev

--- a/cn-lsp/lib/dune
+++ b/cn-lsp/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name cnlsp)
- (libraries base cn linol linol-lwt lsp))
+ (libraries base cn linol linol-lwt lsp telemetry))
 
 (env
  (dev

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -81,7 +81,9 @@ class lsp_server (env : LspCn.cerb_env) =
       : unit IO.t =
       let uri = DocumentUri.to_string doc.uri in
       Log.d (sprintf "Opened document %s" uri);
-      let event_data = EventData.{ event_type = OpenFile uri; event_result = None } in
+      let event_data =
+        EventData.{ event_type = OpenFile { file = uri }; event_result = None }
+      in
       self#record_telemetry event_data;
       IO.return ()
 
@@ -102,7 +104,9 @@ class lsp_server (env : LspCn.cerb_env) =
       : unit IO.t =
       let uri = DocumentUri.to_string doc.uri in
       Log.d (sprintf "Closed document %s" uri);
-      let event_data = EventData.{ event_type = CloseFile uri; event_result = None } in
+      let event_data =
+        EventData.{ event_type = CloseFile { file = uri }; event_result = None }
+      in
       self#record_telemetry event_data;
       IO.return ()
 

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -35,7 +35,10 @@ let cinfo (notify : Rpc.notify_back) (msg : string) : unit IO.t =
 
 module Config = struct
   (** The client controls these options, and sends them at a server's request *)
-  type t = { run_CN_on_save : bool [@key "runOnSave"] }
+  type t =
+    { run_CN_on_save : bool [@key "runOnSave"]
+    ; telemetry_dir : string option [@default None] [@key "telemetryDir"]
+    }
   [@@deriving yojson { strict = false }]
   (* `strict = false` to account for extra configuration fields the client
      defines but which the server doesn't care about (e.g., at the moment,
@@ -46,7 +49,7 @@ module Config = struct
       CN-specific settings *)
   let section : string = "CN"
 
-  let default : t = { run_CN_on_save = false }
+  let default : t = { run_CN_on_save = false; telemetry_dir = None }
 end
 
 let sprintf = Printf.sprintf

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -180,6 +180,14 @@ class lsp_server (env : LspCn.cerb_env) =
         return `Null
       | _ -> failwith ("Unknown method: " ^ method_name)
 
+    method on_req_shutdown
+      ~notify_back:(_ : Rpc.notify_back)
+      ~id:(_ : Jsonrpc.Id.t)
+      : unit IO.t =
+      let event_data = EventData.{ event_type = ServerStop; event_result = None } in
+      self#record_telemetry event_data;
+      IO.return ()
+
     (***************************************************************)
     (***  Other  ***************************************************)
 

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -5,6 +5,7 @@ module EventData = struct
 
   type event_type =
     | ServerStart
+    | ServerStop
     | OpenFile of string
     | CloseFile of string
   [@@deriving eq, show, yojson]

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -6,6 +6,8 @@ module EventData = struct
   type event_type =
     | ServerStart
     | ServerStop
+    | BeginVerify of { file : string }
+    | EndVerify of { file : string }
     | OpenFile of string
     | CloseFile of string
   [@@deriving eq, show, yojson]

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -19,10 +19,6 @@ module EventData = struct
 
   type event_result =
     | Success
-    | PartialSuccess of
-        { successes : int
-        ; failures : int
-        }
     | Failure
   [@@deriving eq, show, yojson]
 

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -3,13 +3,18 @@ open Base
 module EventData = struct
   let source : string = "cn-lsp-server"
 
+  (* Note: when creating (non-singleton) constructors of any sum types in this
+     module, make them contain record data (e.g. [Foo of { thing : int }]),
+     rather than bare values (e.g. [Foo of int]). This will hopefully simplify
+     third-party consumption of any JSON-serialized values of this type. *)
+
   type event_type =
     | ServerStart
     | ServerStop
     | BeginVerify of { file : string }
     | EndVerify of { file : string }
-    | OpenFile of string
-    | CloseFile of string
+    | OpenFile of { file : string }
+    | CloseFile of { file : string }
   [@@deriving eq, show, yojson]
 
   type event_result =

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -1,0 +1,30 @@
+open Base
+
+module EventData = struct
+  let source : string = "cn-lsp-server"
+
+  type event_type =
+    | ServerStart
+    | OpenFile of string
+    | CloseFile of string
+  [@@deriving eq, show, yojson]
+
+  type event_result =
+    | Success
+    | PartialSuccess of
+        { successes : int
+        ; failures : int
+        }
+    | Failure
+  [@@deriving eq, show, yojson]
+
+  type t =
+    { event_type : event_type
+    ; event_result : event_result option
+    }
+  [@@deriving eq, show, yojson]
+end
+
+module ProfileData = struct
+  type t = { id : string } [@@deriving eq, show, yojson]
+end

--- a/dune-project
+++ b/dune-project
@@ -49,7 +49,8 @@
   (lsp
    (and
     (>= 1.17.0)
-    (< 2.0.0)))))
+    (< 2.0.0)))
+  telemetry))
 
 (package
  (name telemetry)


### PR DESCRIPTION
In furtherance of #125, this implements generation and serialization of timestamped telemetry events for several key points in the server/verification lifecycle, mentioned in that issue:
- Server startup
- Server shutdown
- File open
- File close
- Beginning of verification attempt
- End of verification, including outcome

It also updates the client to allow a user to choose whether to collect and where to store telemetry. This collection is disabled by default.

This leaves some aspects of #125 unimplemented:
1. Generation/collection and serialization of user profile information (e.g. user identifiers, expertise levels)
2. Recording telemetry on {re,}configuration of client/server preferences
3. Determining and ascribing task identifiers to telemetry events

There are no technical blockers to implementing (1) and (2), and they're next on my list. I think there are also no technical blockers for (3), but I don't yet know how, abstractly, we want to define a task. (@kschleisman, I'm hoping we can cover this when you're in town next week.)