### PR TITLE
client, server: allow associating user information with telemetry

### DIFF
--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -53,6 +53,11 @@
                     "type": "string",
                     "default": null,
                     "description": "Where to store telemetry. Changes take effect on server start/restart."
+                },
+                "CN.userID": {
+                    "type": "string",
+                    "default": null,
+                    "description": "A user ID to associate with telemetry. Changes take effect on server start/restart."
                 }
             }
         },

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -44,6 +44,7 @@ module Config = struct
   type t =
     { run_CN_on_save : bool [@key "runOnSave"]
     ; telemetry_dir : string option [@default None] [@key "telemetryDir"]
+    ; user_id : string option [@default None] [@key "userID"]
     }
   [@@deriving yojson { strict = false }]
   (* `strict = false` to account for extra configuration fields the client
@@ -55,7 +56,7 @@ module Config = struct
       CN-specific settings *)
   let section : string = "CN"
 
-  let default : t = { run_CN_on_save = false; telemetry_dir = None }
+  let default : t = { run_CN_on_save = false; telemetry_dir = None; user_id = None }
 end
 
 let sprintf = Printf.sprintf


### PR DESCRIPTION
In particular, offer users the option to associate a custom (string) identifier with the telemetry they generate. This option appears in the extension's settings, alongside the choice of whether to collect/where to store telemetry.

If we need more complex identifiers than strings, this setup is extensible enough to read and store them. However, per https://github.com/GaloisInc/VERSE-Toolchain/issues/125#issuecomment-2486089899, we're hoping to avoid soliciting or storing a ton of PII here, so I've kept this minimal.