### PR TITLE
server: telemetry for configuration changes

### DIFF
--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -128,6 +128,11 @@ class lsp_server (env : LspCn.cerb_env) =
            let old_telemetry_dir = server_config.telemetry_dir in
            server_config <- cfg;
            let new_telemetry_dir = server_config.telemetry_dir in
+           let change_event =
+             EventData.
+               { event_type = ChangeConfiguration { cfg }; event_result = Some Success }
+           in
+           self#record_telemetry change_event;
            if not (Option.equal String.equal old_telemetry_dir new_telemetry_dir)
            then
              cinfo

--- a/cn-lsp/lib/serverConfig.ml
+++ b/cn-lsp/lib/serverConfig.ml
@@ -6,7 +6,7 @@ type t =
   ; telemetry_dir : string option [@default None] [@key "telemetryDir"]
   ; user_id : string option [@default None] [@key "userID"]
   }
-[@@deriving yojson { strict = false }]
+[@@deriving eq, show, yojson { strict = false }]
 
 (* `strict = false` to account for extra configuration fields the client
    defines but which the server doesn't care about (e.g., at the moment,

--- a/cn-lsp/lib/serverConfig.ml
+++ b/cn-lsp/lib/serverConfig.ml
@@ -1,0 +1,20 @@
+open! Base
+
+(** The client controls these options, and sends them at a server's request *)
+type t =
+  { run_CN_on_save : bool [@key "runOnSave"]
+  ; telemetry_dir : string option [@default None] [@key "telemetryDir"]
+  ; user_id : string option [@default None] [@key "userID"]
+  }
+[@@deriving yojson { strict = false }]
+
+(* `strict = false` to account for extra configuration fields the client
+   defines but which the server doesn't care about (e.g., at the moment,
+   "cerbRuntime"). There's probably a more idiomatic way to handle this - have
+   the client put such fields in a different "section", perhaps? *)
+
+(** The name of the configuration "section" the client uses to identify
+    CN-specific settings *)
+let section : string = "CN"
+
+let default : t = { run_CN_on_save = false; telemetry_dir = None; user_id = None }

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -15,6 +15,7 @@ module EventData = struct
     | EndVerify of { file : string }
     | OpenFile of { file : string }
     | CloseFile of { file : string }
+    | ChangeConfiguration of { cfg : ServerConfig.t }
   [@@deriving eq, show, yojson]
 
   type event_result =


### PR DESCRIPTION
Each time a user updates a configuration setting, as well as once on startup, the new configuration will be recorded in the user's telemetry.