### PR TITLE
server: record summarized error contents in telemetry

### DIFF
--- a/cn-lsp/lib/lspCn.ml
+++ b/cn-lsp/lib/lspCn.ml
@@ -7,13 +7,10 @@ module Error = struct
   let to_string (err : t) : string =
     let report = Cn.TypeErrors.pp_message err.msg in
     let short = Cn.Pp.plain report.short in
-    let desc = Option.value (Option.map report.descr ~f:Cn.Pp.plain) ~default:"<none>" in
-    "CN Error: loc = "
-    ^ Cn.Locations.to_string err.loc
-    ^ ", short = "
-    ^ short
-    ^ ", desc = "
-    ^ desc
+    let loc = Cn.Locations.to_string err.loc in
+    match report.descr with
+    | None -> Printf.sprintf "%s: %s" loc short
+    | Some desc -> Printf.sprintf "%s: %s (%s)" loc short (Cn.Pp.plain desc)
   ;;
 
   let to_diagnostic (err : t) : (Uri.t * Diagnostic.t) option =

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -20,7 +20,7 @@ module EventData = struct
 
   type event_result =
     | Success
-    | Failure
+    | Failure of { causes : string list }
   [@@deriving eq, show, yojson]
 
   type t =


### PR DESCRIPTION
At present, telemetry events simply encode whether the event ended in success, failure, or neither. This expands the failure outcome to represent optional, additional context about the failure, and fills it with summaries of verification failures from Cerberus and CN.

This additional context is not particularly structured - it's basically the Cerberus/CN-defined pretty-printed version of the error, as a user would see in a tooltip. For example, here's how an error summary might appear in JSON-encoded telemetry:
```json
{
  ...
  "causes": [
    "/Users/sam/projects/verse/cn-tutorial/src/examples/dll/add_orig.broken.c:15:9-27: Left-over unused resource 'Owned<struct dllist*>(&call_malloc__dllist0.return->next)(NULL)'"
  ],
  ...
}
```

I don't know whether this is a sufficient substitute for properly-structured error representations. In the longer term, I imagine that telemetry consumers would benefit from more structure, but I think there's definite value in the shorter term in providing at least something other than an opaque success/failure outcome.