### PR TITLE
server: update CN

### DIFF
--- a/cn-lsp.opam
+++ b/cn-lsp.opam
@@ -8,9 +8,9 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "4.14.1" & < "6.0.0"}
   "base" {>= "v0.16.3" & < "v0.18"}
-  "cerberus" {= "b9daa22"}
-  "cerberus-lib" {= "b9daa22"}
-  "cn" {= "b9daa22"}
+  "cerberus" {= "d7d4e67"}
+  "cerberus-lib" {= "d7d4e67"}
+  "cn" {= "d7d4e67"}
   "jsonrpc" {>= "1.17.0" & < "2.0.0"}
   "linol" {>= "0.6" & < "0.7"}
   "linol-lwt" {>= "0.6" & < "0.7"}
@@ -35,15 +35,15 @@ build: [
 ]
 pin-depends: [
   [
-    "cerberus.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cerberus.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
   [
-    "cerberus-lib.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cerberus-lib.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
   [
-    "cn.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cn.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
 ]

--- a/cn-lsp.opam.locked-5.1.1
+++ b/cn-lsp.opam.locked-5.1.1
@@ -15,10 +15,10 @@ depends: [
   "base-nnp" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "cerberus" {= "b9daa22"}
-  "cerberus-lib" {= "b9daa22"}
+  "cerberus" {= "d7d4e67"}
+  "cerberus-lib" {= "d7d4e67"}
   "cmdliner" {= "1.3.0"}
-  "cn" {= "b9daa22"}
+  "cn" {= "d7d4e67"}
   "conf-findutils" {= "1"}
   "conf-gmp" {= "4"}
   "conf-pkg-config" {= "4"}
@@ -92,15 +92,15 @@ build: [
 ]
 pin-depends: [
   [
-    "cerberus.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cerberus.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
   [
-    "cerberus-lib.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cerberus-lib.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
   [
-    "cn.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cn.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
 ]

--- a/cn-lsp.opam.template
+++ b/cn-lsp.opam.template
@@ -1,14 +1,14 @@
 pin-depends: [
   [
-    "cerberus.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cerberus.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
   [
-    "cerberus-lib.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cerberus-lib.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
   [
-    "cn.b9daa22"
-    "git+https://github.com/rems-project/cerberus.git#b9daa22"
+    "cn.d7d4e67"
+    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
   ]
 ]

--- a/cn-lsp/lib/lspCerb.ml
+++ b/cn-lsp/lib/lspCerb.ml
@@ -77,8 +77,7 @@ let setup () : env m =
       exec_mode
       error_verbosity;
     CF.Ocaml_implementation.set CF.Ocaml_implementation.HafniumImpl.impl;
-    CF.Switches.set [ "inner_arg_temps"; "at_magic_comments" ];
-    CF.Core_peval.config_unfold_stdlib := Cn.Sym.has_id_with Cn.Setup.unfold_stdlib_name
+    CF.Switches.set [ "inner_arg_temps"; "at_magic_comments" ]
   in
   let* stdlib = CB.Pipeline.load_core_stdlib () in
   let* impl = CB.Pipeline.load_core_impl stdlib Cn.Setup.impl_name in
@@ -91,7 +90,7 @@ let frontend ((conf, impl, stdlib) : env) (filename : string) =
     { predicates = [ Cn.Alloc.Predicate.(str, sym, Some loc) ]
     ; functions =
         List.map Cn.Builtins.cn_builtin_fun_names ~f:(fun (str, sym) -> str, sym, None)
-    ; idents = [ Cn.Alloc.History.(str, sym, Some loc) ]
+    ; idents = [ Cn.Alloc.History.(str, sym, None) ]
     }
   in
   let* _, ail_prog_opt, prog0 =

--- a/cn-lsp/lib/lspCn.ml
+++ b/cn-lsp/lib/lspCn.ml
@@ -29,9 +29,9 @@ module Error = struct
   ;;
 end
 
-type 'a m = 'a Cn.Resultat.t
+type 'a m = 'a Cn.Or_TypeError.t
 
-let ( let* ) (a : 'a m) (f : 'a -> 'b m) : 'b m = Cn.Resultat.bind a f
+let ( let* ) (a : 'a m) (f : 'a -> 'b m) : 'b m = Cn.Or_TypeError.bind a f
 
 (* No reason in principle not to have `return`, it just hasn't been used so
    far in practice *)

--- a/cn-lsp/lib/verify.ml
+++ b/cn-lsp/lib/verify.ml
@@ -63,6 +63,9 @@ let setup () : cerb_env m =
     interpret the result, and [error_to_string] and [error_to_diagnostic] to
     process any errors. *)
 let run_cn (cerb_env : cerb_env) (uri : Uri.t) : Error.t list m =
+  (* See https://github.com/GaloisInc/VERSE-Toolchain/issues/142 and
+     https://github.com/rems-project/cerberus/pull/833 *)
+  Cn.Solver.reset_model_evaluator_state ();
   (* CLI flag? *)
   let inherit_loc : bool = true in
   let path = Uri.to_path uri in

--- a/dune-project
+++ b/dune-project
@@ -25,11 +25,11 @@
     (>= v0.16.3)
     (< v0.18)))
   (cerberus
-   (= "b9daa22"))
+   (= "d7d4e67"))
   (cerberus-lib
-   (= "b9daa22"))
+   (= "d7d4e67"))
   (cn
-   (= "b9daa22"))
+   (= "d7d4e67"))
   (jsonrpc
    (and
     (>= 1.17.0)


### PR DESCRIPTION
Update CN to the latest commit available at press time, https://github.com/rems-project/cerberus/commit/d7d4e67fdb049dc35dc5fbd61a702d789394bf3d. Additionally, make use of the new solver-resetting interface made available via https://github.com/rems-project/cerberus/pull/833, which this update pulls in.

Fixes #142.