### PR TITLE
client, server: allow verification of individual functions via code lenses

### DIFF
--- a/cn-client/README.md
+++ b/cn-client/README.md
@@ -48,6 +48,10 @@ wrong, a window should appear to tell you that. If something is wrong, you
 should (hopefully) see CN errors rendered inline as red "squiggles", either in
 the current file or in a file it depends on.
 
+You can run CN on individual functions in a file, instead of on the file at
+large, by clicking on the "code lens" that should appear above each function in
+the file.
+
 You can also choose to run CN on the current (`.c` or `.h`) file whenever it's
 saved, by opening settings (Cmd-,), searching for "CN", and selecting the
 checkbox for "Run On Save". You may not want to select this option if you're

--- a/cn-client/package-lock.json
+++ b/cn-client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cn-client",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cn-client",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "dependencies": {
                 "vscode-languageclient": "^9.0.1"
             },

--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/GaloisInc/VERSE-Toolchain",
         "type": "git"
     },
-    "version": "0.0.4",
+    "version": "0.0.5",
     "engines": {
         "vscode": "^1.75.0"
     },

--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -29,6 +29,10 @@
             {
                 "command": "CN.runOnFile",
                 "title": "CN: Run CN on the current file"
+            },
+            {
+                "command": "CN.runOnFunction",
+                "title": "CN: Run CN on the specified function"
             }
         ],
         "configuration": {

--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -64,23 +64,32 @@ export async function activate(context: vsc.ExtensionContext): Promise<void> {
     );
 
     vsc.commands.registerCommand("CN.runOnFile", () => {
-        const req = new ct.RequestType("$/runCN");
+        runCN();
+    });
 
-        const activeEditor = vsc.window.activeTextEditor;
-        if (activeEditor === undefined) {
-            vsc.window.showErrorMessage("CN client: no file currently open");
-            return;
-        }
-
-        const params: VerifyParams = {
-            uri: activeEditor.document.uri.toString(),
-        };
-
-        client.sendRequest(req, params);
+    vsc.commands.registerCommand("CN.runOnFunction", (functionName: string) => {
+        runCN(functionName);
     });
 
     client.start();
     console.log("started client");
+}
+
+async function runCN(fn?: string) {
+    const req = new ct.RequestType("$/runCN");
+
+    const activeEditor = vsc.window.activeTextEditor;
+    if (activeEditor === undefined) {
+        vsc.window.showErrorMessage("CN client: no file currently open");
+        return;
+    }
+
+    const params: VerifyParams = {
+        uri: activeEditor.document.uri.toString(),
+        fn,
+    };
+
+    client.sendRequest(req, params);
 }
 
 // This schema is meant to match the one defined by `cn-lsp`'s

--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -71,19 +71,23 @@ export async function activate(context: vsc.ExtensionContext): Promise<void> {
             vsc.window.showErrorMessage("CN client: no file currently open");
             return;
         }
-        const doc = activeEditor.document;
 
-        const params: ct.DidSaveTextDocumentParams = {
-            textDocument: {
-                uri: doc.uri.toString(),
-            },
+        const params: VerifyParams = {
+            uri: activeEditor.document.uri.toString(),
         };
+
         client.sendRequest(req, params);
     });
 
     client.start();
     console.log("started client");
 }
+
+// This schema is meant to match the one defined by `cn-lsp`'s
+// `Server.VerifyParams.t` type.
+type VerifyParams = {
+    uri: ct.DocumentUri;
+};
 
 export function deactivate(): Thenable<void> | undefined {
     if (!client) {

--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -87,6 +87,7 @@ export async function activate(context: vsc.ExtensionContext): Promise<void> {
 // `Server.VerifyParams.t` type.
 type VerifyParams = {
     uri: ct.DocumentUri;
+    fn?: string;
 };
 
 export function deactivate(): Thenable<void> | undefined {

--- a/cn-lsp/lib/lenses.ml
+++ b/cn-lsp/lib/lenses.ml
@@ -10,7 +10,7 @@ let mk_verify_lens (fundef : Cabs.function_definition) : CodeLens.t option =
   let command =
     Command.create ~command:"CN.runOnFunction" ~title:"Verify with CN" ~arguments ()
   in
-  match Parse.function_loc fundef with
+  match Range.of_cerb_loc (Parse.function_loc fundef) with
   | None ->
     Log.d
       (Printf.sprintf
@@ -26,6 +26,6 @@ let lenses_for (uri : Uri.t) : CodeLens.t list =
     Log.e (Printf.sprintf "Unable to parse file %s: %s" (Uri.to_path uri) e);
     []
   | Ok decls ->
-    let fns = Parse.function_declarations decls in
+    let fns = Parse.function_declarations decls ~only_from:(Some uri) in
     List.filter_map fns ~f:mk_verify_lens
 ;;

--- a/cn-lsp/lib/lenses.ml
+++ b/cn-lsp/lib/lenses.ml
@@ -1,0 +1,31 @@
+open! Base
+module CodeLens = Lsp.Types.CodeLens
+module CodeLensOptions = Lsp.Types.CodeLensOptions
+module Command = Lsp.Types.Command
+module Cabs = Cerb_frontend.Cabs
+
+let mk_verify_lens (fundef : Cabs.function_definition) : CodeLens.t option =
+  let procedure_name = Parse.function_name fundef in
+  let arguments = [ `String procedure_name ] in
+  let command =
+    Command.create ~command:"CN.runOnFunction" ~title:"Verify with CN" ~arguments ()
+  in
+  match Parse.function_loc fundef with
+  | None ->
+    Log.d
+      (Printf.sprintf
+         "No location available for verification lens for function '%s'"
+         procedure_name);
+    None
+  | Some range -> Some (CodeLens.create ~command ~range ())
+;;
+
+let lenses_for (uri : Uri.t) : CodeLens.t list =
+  match Parse.parse_document_file uri with
+  | Error e ->
+    Log.e (Printf.sprintf "Unable to parse file %s: %s" (Uri.to_path uri) e);
+    []
+  | Ok decls ->
+    let fns = Parse.function_declarations decls in
+    List.filter_map fns ~f:mk_verify_lens
+;;

--- a/cn-lsp/lib/parse.ml
+++ b/cn-lsp/lib/parse.ml
@@ -1,0 +1,123 @@
+open! Base
+module CF = Cerb_frontend
+module Cabs = Cerb_frontend.Cabs
+
+let rec declarator_name (declarator : Cabs.declarator) : string =
+  match declarator with
+  | Cabs.Declarator (_pdecl, ddecl) -> direct_declarator_name ddecl
+
+and direct_declarator_name (declarator : Cabs.direct_declarator) : string =
+  match declarator with
+  | Cabs.DDecl_identifier (_attrs, Identifier (_loc, s)) -> s
+  | Cabs.DDecl_declarator decl -> declarator_name decl
+  | Cabs.DDecl_array (ddecl, _adecl) -> direct_declarator_name ddecl
+  | Cabs.DDecl_function (ddecl, _params) -> direct_declarator_name ddecl
+;;
+
+let function_name (fd : Cabs.function_definition) : string =
+  match fd with
+  | Cabs.FunDef (_loc, _attrs, _specifiers, declarator, _stmt) ->
+    declarator_name declarator
+;;
+
+let function_loc
+  (Cabs.FunDef (loc, _attrs, _specifiers, _declarator, _stmt) : Cabs.function_definition)
+  : Range.t option
+  =
+  Range.of_cerb_loc loc
+;;
+
+let function_declarations (decls : Cabs.external_declaration list)
+  : Cabs.function_definition list
+  =
+  List.filter_map decls ~f:(fun decl ->
+    match decl with
+    | Cabs.EDecl_func fd -> Some fd
+    | Cabs.EDecl_decl _
+    | Cabs.EDecl_magic _
+    | Cabs.EDecl_funcCN _
+    | Cabs.EDecl_lemmaCN _
+    | Cabs.EDecl_predCN _
+    | Cabs.EDecl_datatypeCN _
+    | Cabs.EDecl_type_synCN _
+    | Cabs.EDecl_fun_specCN _ -> None)
+;;
+
+let c_preprocessor : string = "cc"
+
+let c_preprocessor_arguments : string list =
+  [ (* Set standard to C11 *)
+    "-std=c11"
+  ; (* Run in preprocessor mode *)
+    "-E"
+  ; (* ??? *)
+    "-CC"
+  ; (* Disable standard inclusions *)
+    "-nostdinc"
+  ; (* ??? *)
+    "-undef"
+  ; (* TODO: should be able to do these only once, or avoid them entirely? *)
+    "-I"
+  ; Cerb_runtime.in_runtime "libc/include"
+  ; "-I"
+  ; Cerb_runtime.in_runtime "libcore"
+  ; "-include"
+  ; Cerb_runtime.in_runtime "libc/include/builtins.h"
+  ; "-DDEBUG"
+  ; "-DCN_MODE"
+  ]
+;;
+
+type proc_out =
+  { exit_code : int
+  ; stdout : string
+  ; stderr : string
+  }
+
+let read_process (cmd : string) (args : string array) : (proc_out, string) Result.t =
+  try
+    let out_read, out_write = Unix.pipe () in
+    Unix.set_close_on_exec out_read;
+    let out_ic = Unix.in_channel_of_descr out_read in
+    let err_read, err_write = Unix.pipe () in
+    Unix.set_close_on_exec err_read;
+    let err_ic = Unix.in_channel_of_descr err_read in
+    let pid = Unix.create_process cmd args Unix.stdin out_write err_write in
+    Unix.close out_write;
+    Unix.close err_write;
+    Stdlib.flush_all ();
+    let out = In_channel.input_all out_ic in
+    Stdlib.close_in out_ic;
+    let err = In_channel.input_all err_ic in
+    Stdlib.close_in err_ic;
+    match Unix.waitpid [] pid with
+    | _, WEXITED exit_code | _, WSIGNALED exit_code | _, WSTOPPED exit_code ->
+      Ok { exit_code; stdout = out; stderr = err }
+  with
+  | Unix.Unix_error (err, fn, _param) -> Error (Unix.error_message err ^ ": " ^ fn)
+;;
+
+let preprocess_file (uri : Uri.t) : (proc_out, string) Result.t =
+  let path = Uri.to_path uri in
+  let args = Array.of_list (c_preprocessor_arguments @ [ path ]) in
+  read_process c_preprocessor args
+;;
+
+let parse_document_source (uri : Uri.t) (source : string)
+  : (Cabs.external_declaration list, string) Result.t
+  =
+  let () = CF.Switches.set [ "inner_arg_temps"; "at_magic_comments" ] in
+  let path = Uri.to_path uri in
+  match C_parser_driver.parse_from_string ~filename:path source with
+  | CF.Exception.Result (TUnit decls) -> Ok decls
+  | CF.Exception.Exception (loc, cause) -> Error (CF.Pp_errors.to_string (loc, cause))
+;;
+
+let parse_document_file (uri : Uri.t) : (Cabs.external_declaration list, string) Result.t =
+  match preprocess_file uri with
+  | Ok out ->
+    Log.d (Printf.sprintf "cpp exit code: %i" out.exit_code);
+    Log.d (Printf.sprintf "cpp stderr: \n%s" out.stderr);
+    parse_document_source uri out.stdout
+  | Error s -> Error s
+;;

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -261,7 +261,7 @@ class lsp_server (env : Verify.cerb_env) =
           ; event_result = Some (Failure { causes })
           }
       in
-      match Verify.(run_cn env uri) with
+      match Verify.(run_cn env uri ~fn:None) with
       | Ok [] ->
         let end_event =
           EventData.

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -7,12 +7,15 @@ module IO = Rpc.IO
 
 (* LSP Types *)
 module CNotif = Lsp.Client_notification
+module CodeLens = Lsp.Types.CodeLens
+module CodeLensOptions = Lsp.Types.CodeLensOptions
 module ConfigurationItem = Lsp.Types.ConfigurationItem
 module ConfigurationParams = Lsp.Types.ConfigurationParams
 module Diagnostic = Lsp.Types.Diagnostic
 module DidSaveTextDocumentParams = Lsp.Types.DidSaveTextDocumentParams
 module DocumentUri = Lsp.Types.DocumentUri
 module MessageType = Lsp.Types.MessageType
+module ProgressToken = Lsp.Types.ProgressToken
 module PublishDiagnosticsParams = Lsp.Types.PublishDiagnosticsParams
 module Registration = Lsp.Types.Registration
 module RegistrationParams = Lsp.Types.RegistrationParams
@@ -160,6 +163,16 @@ class lsp_server (env : Verify.cerb_env) =
     (***************************************************************)
     (***  Requests  ************************************************)
 
+    method on_req_code_lens
+      ~notify_back:(_ : Rpc.notify_back)
+      ~id:(_ : Jsonrpc.Id.t)
+      ~(uri : DocumentUri.t)
+      ~workDoneToken:(_ : ProgressToken.t option)
+      ~partialResultToken:(_ : ProgressToken.t option)
+      (_ : Rpc.doc_state)
+      : CodeLens.t list IO.t =
+      IO.return (Lenses.lenses_for uri)
+
     method on_unknown_request
       ~(notify_back : Rpc.notify_back)
       ~server_request:(_ : Rpc.server_request_handler_pair -> Jsonrpc.Id.t IO.t)
@@ -184,6 +197,8 @@ class lsp_server (env : Verify.cerb_env) =
 
     (***************************************************************)
     (***  Other  ***************************************************)
+
+    method config_code_lens_options = Some (CodeLensOptions.create ())
 
     (** Fetch the client's current configuration *)
     method fetch_configuration (notify_back : Rpc.notify_back) : ServerConfig.t IO.t =

--- a/cn-lsp/lib/uri.ml
+++ b/cn-lsp/lib/uri.ml
@@ -1,5 +1,6 @@
 open! Base
-
 include Lsp.Types.DocumentUri
 
 let sexp_of_t (uri : t) : Sexp.t = String.sexp_of_t (to_path uri)
+let to_yojson (uri : t) : Yojson.Safe.t = yojson_of_t uri
+let of_yojson (js : Yojson.Safe.t) : (t, string) Result.t = Ok (t_of_yojson js)

--- a/cn-lsp/lib/verify.ml
+++ b/cn-lsp/lib/verify.ml
@@ -59,10 +59,9 @@ let setup () : cerb_env m =
   return env
 ;;
 
-(** Run CN on the given document to potentially produce errors. Use [run] to
-    interpret the result, and [error_to_string] and [error_to_diagnostic] to
-    process any errors. *)
-let run_cn (cerb_env : cerb_env) (uri : Uri.t) : Error.t list m =
+(** In the given document, run CN (on [fn] if it's provided, or on every
+    function in the file if it's not) to potentially produce errors. *)
+let run_cn (cerb_env : cerb_env) (uri : Uri.t) ~(fn : string option) : Error.t list m =
   (* See https://github.com/GaloisInc/VERSE-Toolchain/issues/142 and
      https://github.com/rems-project/cerberus/pull/833 *)
   Cn.Solver.reset_model_evaluator_state ();
@@ -72,6 +71,7 @@ let run_cn (cerb_env : cerb_env) (uri : Uri.t) : Error.t list m =
   let* prog, (markers_env, ail_prog), _statement_locs =
     lift_cerb (LspCerb.frontend cerb_env path)
   in
+  Cn.Check.skip_and_only := [], Option.to_list fn;
   let* errors =
     lift_cn
       LspCn.(


### PR DESCRIPTION
[Code lenses](https://code.visualstudio.com/blogs/2017/02/12/code-lens-roundup) are small, clickable buttons that can appear at specific points in code. With these changes, the server will publish one such lens per function in a file, which can be used to verify only that function, instead of verifying every function in a file (and in its `#include`d dependencies).

Here's an example of how this looks in practice:
<img width="420" alt="Screenshot 2025-02-13 at 4 46 29 PM" src="https://github.com/user-attachments/assets/aca40586-ea17-4218-96b2-b7cc87fa3d97" />