### PR TITLE
server: record function names, bodies, specs in telemetry

### DIFF
--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -75,7 +75,7 @@ export async function activate(context: vsc.ExtensionContext): Promise<void> {
     console.log("started client");
 }
 
-async function runCN(fn?: string) {
+async function runCN(functionName?: string, functionRange?: ct.Range) {
     const req = new ct.RequestType("$/runCN");
 
     const activeEditor = vsc.window.activeTextEditor;
@@ -86,7 +86,8 @@ async function runCN(fn?: string) {
 
     const params: VerifyParams = {
         uri: activeEditor.document.uri.toString(),
-        fn,
+        fn: functionName,
+        fnRange: functionRange
     };
 
     client.sendRequest(req, params);
@@ -97,6 +98,7 @@ async function runCN(fn?: string) {
 type VerifyParams = {
     uri: ct.DocumentUri;
     fn?: string;
+    fnRange?: ct.Range;
 };
 
 export function deactivate(): Thenable<void> | undefined {

--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -67,9 +67,12 @@ export async function activate(context: vsc.ExtensionContext): Promise<void> {
         runCN();
     });
 
-    vsc.commands.registerCommand("CN.runOnFunction", (functionName: string) => {
-        runCN(functionName);
-    });
+    vsc.commands.registerCommand(
+        "CN.runOnFunction",
+        (functionName: string, functionRange: ct.Range) => {
+            runCN(functionName, functionRange);
+        }
+    );
 
     client.start();
     console.log("started client");

--- a/cn-lsp/lib/lenses.ml
+++ b/cn-lsp/lib/lenses.ml
@@ -6,10 +6,6 @@ module Cabs = Cerb_frontend.Cabs
 
 let mk_verify_lens (fundef : Cabs.function_definition) : CodeLens.t option =
   let procedure_name = Parse.function_name fundef in
-  let arguments = [ `String procedure_name ] in
-  let command =
-    Command.create ~command:"CN.runOnFunction" ~title:"Verify with CN" ~arguments ()
-  in
   match Range.of_cerb_loc (Parse.function_loc fundef) with
   | None ->
     Log.d
@@ -17,7 +13,12 @@ let mk_verify_lens (fundef : Cabs.function_definition) : CodeLens.t option =
          "No location available for verification lens for function '%s'"
          procedure_name);
     None
-  | Some range -> Some (CodeLens.create ~command ~range ())
+  | Some range ->
+    let arguments = [ `String procedure_name; Range.to_yojson range ] in
+    let command =
+      Command.create ~command:"CN.runOnFunction" ~title:"Verify with CN" ~arguments ()
+    in
+    Some (CodeLens.create ~command ~range ())
 ;;
 
 let lenses_for (uri : Uri.t) : CodeLens.t list =

--- a/cn-lsp/lib/range.ml
+++ b/cn-lsp/lib/range.ml
@@ -24,3 +24,9 @@ let of_cerb_loc (loc : Cerb_location.t) : t option =
     let end_ = Position.create ~line:l2 ~character:c2 in
     Some (create ~start ~end_)
 ;;
+
+let to_yojson (range : t) : Yojson.Safe.t = Lsp.Types.Range.yojson_of_t range
+
+let of_yojson (js : Yojson.Safe.t) : (t, string) Result.t =
+  Ok (Lsp.Types.Range.t_of_yojson js)
+;;

--- a/cn-lsp/lib/range.mli
+++ b/cn-lsp/lib/range.mli
@@ -9,3 +9,5 @@ val to_string : t -> string
 val ( |--| ) : int * int -> int * int -> t
 
 val of_cerb_loc : Cerb_location.t -> t option
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, string) Result.t

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -51,6 +51,7 @@ module VerifyParams = struct
   type t =
     { uri : Uri.t
     ; fn : string option [@default None]
+    ; fn_range : Range.t option [@key "fnRange"] [@default None]
     }
   [@@deriving yojson]
 end
@@ -111,7 +112,7 @@ class lsp_server (env : Verify.cerb_env) =
       : unit IO.t =
       let open IO in
       if server_config.run_CN_on_save
-      then self#run_cn notify_back params.textDocument.uri ~fn:None
+      then self#run_cn notify_back params.textDocument.uri ~fn:None ~fn_range:None
       else return ()
 
     method on_notif_initialized (notify_back : Rpc.notify_back) : unit IO.t =
@@ -191,7 +192,7 @@ class lsp_server (env : Verify.cerb_env) =
          | Ok ps ->
            (* The URI isn't set automatically on unknown/custom requests *)
            let () = notify_back#set_uri ps.uri in
-           let* () = self#run_cn notify_back ps.uri ~fn:ps.fn in
+           let* () = self#run_cn notify_back ps.uri ~fn:ps.fn ~fn_range:ps.fn_range in
            return `Null)
       | _ -> failwith ("Unknown method: " ^ method_name)
 
@@ -271,6 +272,7 @@ class lsp_server (env : Verify.cerb_env) =
       (notify_back : Rpc.notify_back)
       (uri : DocumentUri.t)
       ~(fn : string option)
+      ~fn_range:(_ : Range.t option)
       : unit IO.t =
       let open IO in
       let begin_event =

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -275,12 +275,14 @@ class lsp_server (env : Verify.cerb_env) =
       let open IO in
       let begin_event =
         EventData.
-          { event_type = BeginVerify { file = Uri.to_path uri }; event_result = None }
+          { event_type = BeginVerify { file = Uri.to_path uri; fn_name = fn }
+          ; event_result = None
+          }
       in
       self#record_telemetry begin_event;
       let failure (causes : string list) : EventData.t =
         EventData.
-          { event_type = EndVerify { file = Uri.to_path uri }
+          { event_type = EndVerify { file = Uri.to_path uri; fn_name = fn }
           ; event_result = Some (Failure { causes })
           }
       in
@@ -288,7 +290,7 @@ class lsp_server (env : Verify.cerb_env) =
       | Ok [] ->
         let end_event =
           EventData.
-            { event_type = EndVerify { file = Uri.to_path uri }
+            { event_type = EndVerify { file = Uri.to_path uri; fn_name = fn }
             ; event_result = Some Success
             }
         in

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -272,12 +272,15 @@ class lsp_server (env : Verify.cerb_env) =
       (notify_back : Rpc.notify_back)
       (uri : DocumentUri.t)
       ~(fn : string option)
-      ~fn_range:(_ : Range.t option)
+      ~(fn_range : Range.t option)
       : unit IO.t =
       let open IO in
+      let fn_body =
+        Option.map fn_range ~f:(fun range -> Parse.extract_from_file range uri)
+      in
       let begin_event =
         EventData.
-          { event_type = BeginVerify { file = Uri.to_path uri; fn_name = fn }
+          { event_type = BeginVerify { file = Uri.to_path uri; fn_name = fn; fn_body }
           ; event_result = None
           }
       in

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -77,7 +77,7 @@ class lsp_server (env : Verify.cerb_env) =
       : unit IO.t =
       let uri = DocumentUri.to_string doc.uri in
       Log.d (sprintf "Opened document %s" uri);
-      let event_data =
+      let event_data () =
         EventData.{ event_type = OpenFile { file = uri }; event_result = None }
       in
       self#record_telemetry event_data;
@@ -100,7 +100,7 @@ class lsp_server (env : Verify.cerb_env) =
       : unit IO.t =
       let uri = DocumentUri.to_string doc.uri in
       Log.d (sprintf "Closed document %s" uri);
-      let event_data =
+      let event_data () =
         EventData.{ event_type = CloseFile { file = uri }; event_result = None }
       in
       self#record_telemetry event_data;
@@ -122,7 +122,7 @@ class lsp_server (env : Verify.cerb_env) =
       (match server_config.telemetry_dir with
        | None -> ()
        | Some dir -> self#initialize_telemetry dir);
-      let event_data = EventData.{ event_type = ServerStart; event_result = None } in
+      let event_data () = EventData.{ event_type = ServerStart; event_result = None } in
       self#record_telemetry event_data;
       let* () = self#register_did_change_configuration notify_back in
       return ()
@@ -143,7 +143,7 @@ class lsp_server (env : Verify.cerb_env) =
            let old_telemetry_dir = server_config.telemetry_dir in
            server_config <- cfg;
            let new_telemetry_dir = server_config.telemetry_dir in
-           let change_event =
+           let change_event () =
              EventData.
                { event_type = ChangeConfiguration { cfg }; event_result = Some Success }
            in
@@ -275,42 +275,34 @@ class lsp_server (env : Verify.cerb_env) =
       ~(fn_range : Range.t option)
       : unit IO.t =
       let open IO in
-      let fn_body =
-        Option.map fn_range ~f:(fun range -> Parse.extract_from_file range uri)
-      in
-      let begin_event =
+      let begin_event () =
+        let fn_body =
+          Option.map fn_range ~f:(fun range -> Parse.extract_from_file range uri)
+        in
         EventData.
           { event_type = BeginVerify { file = Uri.to_path uri; fn_name = fn; fn_body }
           ; event_result = None
           }
       in
-      self#record_telemetry begin_event;
-      let failure (causes : string list) : EventData.t =
+      let end_event result () =
         EventData.
           { event_type = EndVerify { file = Uri.to_path uri; fn_name = fn }
-          ; event_result = Some (Failure { causes })
+          ; event_result = Some result
           }
       in
+      self#record_telemetry begin_event;
       match Verify.(run_cn env uri ~fn) with
       | Ok [] ->
-        let end_event =
-          EventData.
-            { event_type = EndVerify { file = Uri.to_path uri; fn_name = fn }
-            ; event_result = Some Success
-            }
-        in
-        self#record_telemetry end_event;
+        self#record_telemetry (end_event Success);
         cinfo notify_back "No issues found"
       | Ok errs ->
         let causes = List.map errs ~f:Verify.Error.to_string in
-        let end_event = failure causes in
-        self#record_telemetry end_event;
+        self#record_telemetry (end_event (Failure { causes }));
         let diagnostics = Hashtbl.to_alist (Verify.Error.to_diagnostics errs) in
         self#publish_all notify_back diagnostics
       | Error err ->
-        let cause = Verify.Error.to_string err in
-        let end_event = failure [ cause ] in
-        self#record_telemetry end_event;
+        let causes = [ Verify.Error.to_string err ] in
+        self#record_telemetry (end_event (Failure { causes }));
         (match Verify.Error.to_diagnostic err with
          | None ->
            Log.e (sprintf "Unable to decode error: %s" (Verify.Error.to_string err));
@@ -333,7 +325,7 @@ class lsp_server (env : Verify.cerb_env) =
               Log.d (sprintf "Wrote new ID %s (overwrite existing ID %s)" id prev.id)
             | Ok None -> Log.d (sprintf "Wrote new ID %s" id)))
 
-    method record_telemetry (event_data : EventData.t) : unit =
+    method record_telemetry (mk_event_data : unit -> EventData.t) : unit =
       match server_config.telemetry_dir, telemetry_storage with
       (* No telemetry directory has been configured *)
       | None, _ -> ()
@@ -346,10 +338,13 @@ class lsp_server (env : Verify.cerb_env) =
          startup. *)
       | Some _, Some storage ->
         let session = Telemetry.Session.today () in
-        let event = Event.create ~session ~event_data in
-        (match Storage.store_event storage ~event with
-         | Ok () -> ()
-         | Error _e -> Log.e "couldn't store event")
+        (match mk_event_data () with
+         | exception e -> Log.e ("failed to create event data: " ^ Exn.to_string e)
+         | event_data ->
+           let event = Event.create ~session ~event_data in
+           (match Storage.store_event storage ~event with
+            | Ok () -> ()
+            | Error _e -> Log.e "couldn't store event"))
 
     method clear_diagnostics_for
       (notify_back : Rpc.notify_back)
@@ -420,7 +415,7 @@ let run ~(socket_path : string) : unit =
         (* Note: this is written this way to accomodate linol v0.6 - If
            upgrading to 0.7+, this logic can and should move to the
            [on_req_shutdown] method introduced in 0.7 *)
-        let event_data = EventData.{ event_type = ServerStop; event_result = None } in
+        let event_data () = EventData.{ event_type = ServerStop; event_result = None } in
         cn_server#record_telemetry event_data;
         true
       | `Running -> false

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -11,8 +11,14 @@ module EventData = struct
   type event_type =
     | ServerStart
     | ServerStop
-    | BeginVerify of { file : string }
-    | EndVerify of { file : string }
+    | BeginVerify of
+        { file : string
+        ; fn_name : string option
+        }
+    | EndVerify of
+        { file : string
+        ; fn_name : string option
+        }
     | OpenFile of { file : string }
     | CloseFile of { file : string }
     | ChangeConfiguration of { cfg : ServerConfig.t }

--- a/cn-lsp/lib/serverTelemetry.ml
+++ b/cn-lsp/lib/serverTelemetry.ml
@@ -14,6 +14,7 @@ module EventData = struct
     | BeginVerify of
         { file : string
         ; fn_name : string option
+        ; fn_body : string option
         }
     | EndVerify of
         { file : string

--- a/cn-lsp/test/dune
+++ b/cn-lsp/test/dune
@@ -1,2 +1,3 @@
 (test
- (name test_cnlsp))
+ (name main)
+ (libraries cnlsp alcotest))

--- a/cn-lsp/test/main.ml
+++ b/cn-lsp/test/main.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "cn-lsp" [ "Parse", Parse.tests ]

--- a/cn-lsp/test/parse.ml
+++ b/cn-lsp/test/parse.ml
@@ -1,0 +1,64 @@
+open Base
+
+let source : string =
+  String.concat
+    [ "#define X 42"
+    ; "int foo() {"
+    ; "  int x = X;"
+    ; "  int y = x;"
+    ; "  return x + y;"
+    ; "}"
+    ]
+    ~sep:"\n"
+;;
+
+let file : Cnlsp.Uri.t =
+  let filename = Stdlib.Filename.temp_file "prefix" "suffix" in
+  Out_channel.with_open_text filename (fun oc -> Out_channel.output_string oc source);
+  Cnlsp.Uri.of_path filename
+;;
+
+let check_extract_zero_lines () =
+  let range = Cnlsp.Range.((99, 0) |--| (100, 0)) in
+  let expected = "" in
+  let actual_source = Cnlsp.Parse.extract_from_source range source in
+  let actual_file = Cnlsp.Parse.extract_from_file range file in
+  Alcotest.(check string) "source correct" expected actual_source;
+  Alcotest.(check string) "source matches file" actual_source actual_file
+;;
+
+let check_extract_one_line () =
+  let range = Cnlsp.Range.((0, 1) |--| (0, 7)) in
+  let expected = "define" in
+  let actual_source = Cnlsp.Parse.extract_from_source range source in
+  let actual_file = Cnlsp.Parse.extract_from_file range file in
+  Alcotest.(check string) "source correct" expected actual_source;
+  Alcotest.(check string) "source matches file" actual_source actual_file
+;;
+
+let check_extract_two_lines () =
+  let range = Cnlsp.Range.((0, 1) |--| (1, 7)) in
+  let expected = "define X 42\nint foo" in
+  let actual_source = Cnlsp.Parse.extract_from_source range source in
+  let actual_file = Cnlsp.Parse.extract_from_file range file in
+  Alcotest.(check string) "source correct" expected actual_source;
+  Alcotest.(check string) "source matches file" actual_source actual_file
+;;
+
+let check_extract_three_lines () =
+  let range = Cnlsp.Range.((0, 1) |--| (2, 7)) in
+  let expected = "define X 42\nint foo() {\n  int x" in
+  let actual_source = Cnlsp.Parse.extract_from_source range source in
+  let actual_file = Cnlsp.Parse.extract_from_file range file in
+  Alcotest.(check string) "source correct" expected actual_source;
+  Alcotest.(check string) "source matches file" actual_source actual_file
+;;
+
+let tests =
+  let tc = Alcotest.test_case in
+  [ tc "zero-line range extraction" `Quick check_extract_zero_lines
+  ; tc "one-line range extraction" `Quick check_extract_one_line
+  ; tc "two-line range extraction" `Quick check_extract_two_lines
+  ; tc "three-line range extraction" `Quick check_extract_three_lines
+  ]
+;;


### PR DESCRIPTION
When a user requests verification of an individual function, via the code lenses that #152 introduced, the server will record the name, body, and spec (if any) of that function in a telemetry event.