### PR TITLE
server: report progress during verification

### DIFF
--- a/cn-lsp/lib/progress.ml
+++ b/cn-lsp/lib/progress.ml
@@ -1,0 +1,44 @@
+open Base
+module SNotif = Lsp.Server_notification
+module SReq = Lsp.Server_request
+
+module Token = struct
+  type t = Lsp.Types.ProgressToken.t
+
+  (** Create a fresh, nameless token, guaranteed to be different from all
+      previously-created tokens *)
+  let anonymous : unit -> t =
+    let fresh = ref 0 in
+    fun () ->
+      let i = !fresh in
+      fresh := i + 1;
+      `Int i
+  ;;
+
+  (** Create a named token, which may be the same as another token *)
+  let named (s : string) : t = `String s
+end
+
+(** A server-provided notification for the client to start displaying progress
+    against the given [token]. *)
+let notif_begin (token : Token.t) ~(title : string) : SNotif.t =
+  let begin_ = Lsp.Types.WorkDoneProgressBegin.create ~title () in
+  let progress = Lsp.Progress.Begin begin_ in
+  let params = Lsp.Types.ProgressParams.create ~token ~value:progress in
+  SNotif.WorkDoneProgress params
+;;
+
+(** A server-provided notification for the client to stop displaying progress
+    against the given [token]. *)
+let notif_end (token : Token.t) : SNotif.t =
+  let end_ = Lsp.Types.WorkDoneProgressEnd.create () in
+  let progress = Lsp.Progress.End end_ in
+  let params = Lsp.Types.ProgressParams.create ~token ~value:progress in
+  SNotif.WorkDoneProgress params
+;;
+
+(** A server-provided request for the client to recognize the given [token]. *)
+let req_create (token : Token.t) : unit SReq.t =
+  let params = Lsp.Types.WorkDoneProgressCreateParams.create ~token in
+  SReq.WorkDoneProgressCreate params
+;;

--- a/cn-lsp/lib/server.ml
+++ b/cn-lsp/lib/server.ml
@@ -268,6 +268,23 @@ class lsp_server (env : Verify.cerb_env) =
       in
       self#register_capability ~notify_back ~method_ ~registerOptions ()
 
+    method register_progress_token
+      (notify_back : Rpc.notify_back)
+      (token : Progress.Token.t)
+      : unit IO.t =
+      let open IO in
+      let handle (response : (unit, Jsonrpc.Response.Error.t) Result.t) : unit IO.t =
+        match response with
+        | Ok () ->
+          Log.d "register_progress_token: successfully registered token";
+          return ()
+        | Error e ->
+          Log.e (sprintf "register_progress_token: error registering token: %s" e.message);
+          return ()
+      in
+      let _id = notify_back#send_request (Progress.req_create token) handle in
+      return ()
+
     method run_cn
       (notify_back : Rpc.notify_back)
       (uri : DocumentUri.t)

--- a/cn-lsp/lib/verify.ml
+++ b/cn-lsp/lib/verify.ml
@@ -25,7 +25,9 @@ module Error = struct
     let diags = Hashtbl.create (module Uri) in
     let add err =
       match to_diagnostic err with
-      | None -> ()
+      | None ->
+        Log.e
+          (Printf.sprintf "to_diagnostics: unable to interpret error: %s" (to_string err))
       | Some (uri, diag) -> Hashtbl.add_multi diags ~key:uri ~data:diag
     in
     List.iter errs ~f:add;


### PR DESCRIPTION
With these changes, the server now leverages LSP-defined [WorkDoneProgress](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgress)-type messages to start displaying progress when verification begins, and to stop displaying it when verification ends. This progress is displayed as indefinite - we don't e.g. report progress incrementally per function in a file.

This progress is displayed as a message in the VSCode status bar at the bottom of a window, like so:
<img width="520" alt="Screenshot 2025-02-17 at 4 36 38 PM" src="https://github.com/user-attachments/assets/3ac7e8b6-2405-4b3f-8d8d-aa765708e8b1" />
