### PR TITLE
server: update build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ TBD: Links to project pages, more details as we discover them.
 ## Installation and Use
 
 Begin by installing OCaml and opam, if need be - here are
-[instructions](https://ocaml.org/docs/installing-ocaml) for how to do so. This
-build process has been tested with OCaml 4.14.1 and 5.1.1, though other versions
-are likely to work as well.
+[instructions](https://ocaml.org/docs/installing-ocaml) for how to do so. We
+recommend using OCaml version 5.1.1.
 
 With a choice of version in hand, the easiest way to build this repo's packages
 is with a local opam switch, like so:
 ```sh
-VERSION=4.14.1  # or 5.1.1
+VERSION=5.1.1  # or e.g. 4.14.1
 ln -s telemetry.opam.locked-$VERSION telemetry.opam.locked
 ln -s cn-lsp.opam.locked-$VERSION cn-lsp.opam.locked
 opam switch create . ocaml.$VERSION --locked -y

--- a/README.md
+++ b/README.md
@@ -55,14 +55,24 @@ Begin by installing OCaml and opam, if need be - here are
 [instructions](https://ocaml.org/docs/installing-ocaml) for how to do so. We
 recommend using OCaml version 5.1.1.
 
-With a choice of version in hand, the easiest way to build this repo's packages
-is with a local opam switch, like so:
+With a choice of version in hand, if you're building from scratch, the easiest
+way to build this repo's packages is with a local opam switch, like so:
 ```sh
 VERSION=5.1.1  # or e.g. 4.14.1
 ln -s telemetry.opam.locked-$VERSION telemetry.opam.locked
 ln -s cn-lsp.opam.locked-$VERSION cn-lsp.opam.locked
 opam switch create . ocaml.$VERSION --locked -y
 eval $(opam env)
+```
+
+If you've previously gone through this switch-initialization process, you should
+be able to activate the existing local switch and rebuild the server most easily
+with `dune`:
+```sh
+opam switch .
+eval $(opam env)
+dune build
+dune install
 ```
 
 If this command succeeds, it should install the `cn-lsp` and `telemetry`


### PR DESCRIPTION
Steer users to OCaml 5.1.1 (a straggler from #146) and to use `dune` for rebuilds.