### PR TITLE
server: structured error-handling for parsing, code lenses

### DIFF
--- a/cn-lsp/lib/lenses.ml
+++ b/cn-lsp/lib/lenses.ml
@@ -4,7 +4,29 @@ module CodeLensOptions = Lsp.Types.CodeLensOptions
 module Command = Lsp.Types.Command
 module Cabs = Cerb_frontend.Cabs
 
-let mk_verify_lens (fundef : Cabs.function_definition) : CodeLens.t option =
+module Error = struct
+  type t =
+    | Parse of Parse.Error.t
+    | FunctionLocation of
+        { fn : string
+        ; loc : Cerb_location.t
+        }
+
+  let to_string (err : t) : string =
+    match err with
+    | Parse e -> Printf.sprintf "parse error: %s" (Parse.Error.to_string e)
+    | FunctionLocation e ->
+      let buf = Buffer.create 1024 in
+      let loc = Cerb_location.print_location e.loc in
+      let () = PPrint.ToBuffer.compact buf loc in
+      Printf.sprintf
+        "error interpreting location for %s (original: %s)"
+        e.fn
+        (Buffer.contents buf)
+  ;;
+end
+
+let mk_verify_lens (fundef : Cabs.function_definition) : (CodeLens.t, Error.t) Result.t =
   let procedure_name = Parse.function_name fundef in
   match Range.of_cerb_loc (Parse.function_loc fundef) with
   | None ->
@@ -12,21 +34,19 @@ let mk_verify_lens (fundef : Cabs.function_definition) : CodeLens.t option =
       (Printf.sprintf
          "No location available for verification lens for function '%s'"
          procedure_name);
-    None
+    Error (FunctionLocation { fn = procedure_name; loc = Parse.function_loc fundef })
   | Some range ->
     let arguments = [ `String procedure_name; Range.to_yojson range ] in
     let command =
       Command.create ~command:"CN.runOnFunction" ~title:"Verify with CN" ~arguments ()
     in
-    Some (CodeLens.create ~command ~range ())
+    Ok (CodeLens.create ~command ~range ())
 ;;
 
-let lenses_for (uri : Uri.t) : CodeLens.t list =
+let lenses_for (uri : Uri.t) : CodeLens.t list * Error.t list =
   match Parse.parse_document_file uri with
-  | Error e ->
-    Log.e (Printf.sprintf "Unable to parse file %s: %s" (Uri.to_path uri) e);
-    []
+  | Error e -> [], [ Error.Parse e ]
   | Ok decls ->
     let fns = Parse.function_declarations decls ~only_from:(Some uri) in
-    List.filter_map fns ~f:mk_verify_lens
+    List.partition_result (List.map fns ~f:mk_verify_lens)
 ;;


### PR DESCRIPTION
To avoid silently failing when we fail to preprocess files, as we currently do on Linux (see #157).