### PR TITLE
server: fix preprocessing arguments

### DIFF
--- a/cn-lsp/lib/parse.ml
+++ b/cn-lsp/lib/parse.ml
@@ -116,6 +116,10 @@ module Error = struct
   ;;
 end
 
+(** Run the command [cmd] with arguments [args] and wait for it to finish. Note
+    that, like [Unix.create_process], the first argument ([args.(0)]) should
+    be "the filename of the program being executed". In most cases, this means
+    it should be [cmd]. *)
 let read_process (cmd : string) (args : string array) : (proc_out, Error.t) Result.t =
   try
     let out_read, out_write = Unix.pipe () in
@@ -142,7 +146,7 @@ let read_process (cmd : string) (args : string array) : (proc_out, Error.t) Resu
 let preprocess_file (uri : Uri.t) : (proc_out, Error.t) Result.t =
   let ( let* ) x f = Result.bind x ~f in
   let path = Uri.to_path uri in
-  let args = Array.of_list (c_preprocessor_arguments @ [ path ]) in
+  let args = Array.of_list ((c_preprocessor :: c_preprocessor_arguments) @ [ path ]) in
   let* result = read_process c_preprocessor args in
   match result.exit_code with
   | 0 -> Ok result

--- a/cn-lsp/test/parse.ml
+++ b/cn-lsp/test/parse.ml
@@ -13,7 +13,7 @@ let source : string =
 ;;
 
 let file : Cnlsp.Uri.t =
-  let filename = Stdlib.Filename.temp_file "prefix" "suffix" in
+  let filename = Stdlib.Filename.temp_file "prefix" ".c" in
   Out_channel.with_open_text filename (fun oc -> Out_channel.output_string oc source);
   Cnlsp.Uri.of_path filename
 ;;
@@ -54,11 +54,30 @@ let check_extract_three_lines () =
   Alcotest.(check string) "source matches file" actual_source actual_file
 ;;
 
+let check_preprocess () =
+  let expected =
+    String.concat
+      [ "int foo() {"; "  int x = 42;"; "  int y = x;"; "  return x + y;"; "}" ]
+      ~sep:"\n"
+  in
+  match Cnlsp.Parse.read_process "cc" [| "cc"; "-E"; Cnlsp.Uri.to_path file |] with
+  | Error e -> failwith ("failed to preprocess: " ^ Cnlsp.Parse.Error.to_string e)
+  | Ok out ->
+    Alcotest.(check int) "exit code zero" 0 out.exit_code;
+    let stdout_lines = String.split_lines out.stdout in
+    let actual = List.rev (List.take (List.rev stdout_lines) 5) in
+    Alcotest.(check string)
+      "preprocessed correct"
+      expected
+      (String.concat actual ~sep:"\n")
+;;
+
 let tests =
   let tc = Alcotest.test_case in
   [ tc "zero-line range extraction" `Quick check_extract_zero_lines
   ; tc "one-line range extraction" `Quick check_extract_one_line
   ; tc "two-line range extraction" `Quick check_extract_two_lines
   ; tc "three-line range extraction" `Quick check_extract_three_lines
+  ; tc "preprocessing" `Quick check_preprocess
   ]
 ;;


### PR DESCRIPTION
Fixes #157.

The issue was, seemingly, that I was invoking `cc` with `Unix.create_process "cc" [| "-std=c11"; "-E"; ... |]`, when in fact I needed to say `Unix.create_process "cc" [| "cc"; "-std=c11"; "-E"; ... |]` - that is, provide `cc` as the 0th argument. I don't know why this wasn't an issue on macOS, but I've tried this method of process-creation on a Linux VM and it seems to solve the problem.