### PR TITLE
server: unpublish lenses for docs with unsaved changes

### DIFF
--- a/docs/tech_notes/2025-2-21-CN-telemetry-setup-guide.md
+++ b/docs/tech_notes/2025-2-21-CN-telemetry-setup-guide.md
@@ -114,7 +114,8 @@ You can find the tutorials
 
 **Note:** The tutorial doesn’t refer to the IDE, but rather the command-line
 tool. In order to collect telemetry, please always run CN by clicking ‘Verify _
-with CN’ in the editor. 
+with CN’ in the editor. If you don't see this button above a function, save the
+file containing that function. This should cause the lens to (re)appear.
 
 ## *Step 8:* Upload your telemetry
 


### PR DESCRIPTION
Code lens positions are calculated based on whatever version of a document is saved to disk. Currently, a document with unsaved changes that change the position of a function can have lenses that appear in the wrong place - see #158. As a temporary fix, this entirely blocks lenses from being published for documents with unsaved changes, removing that block once the document is saved.