### PR TITLE
client: save before verification

### DIFF
--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -93,6 +93,8 @@ async function runCN(functionName?: string, functionRange?: ct.Range) {
         fnRange: functionRange
     };
 
+    await vsc.workspace.save(activeEditor.document.uri);
+
     client.sendRequest(req, params);
 }
 


### PR DESCRIPTION
By saving a document before requesting verification of it, we can avoid spurious verification results as a consequence of #160.