### PR TITLE
docs: describe current telemetry event schema and directory layout

### DIFF
--- a/docs/cn-lsp/2025-02-27-telemetry-schema.json
+++ b/docs/cn-lsp/2025-02-27-telemetry-schema.json
@@ -1,0 +1,270 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "CN Language Server Telemetry",
+    "type": "object",
+    "properties": {
+        "time": {
+            "description": "Timestamp of an event, in seconds since epoch",
+            "type": "number"
+        },
+        "event_data": {
+            "description": "Data associated with an event",
+            "type": "object",
+            "properties": {
+                "event_result": {
+                    "description": "Outcome of event, if any",
+                    "anyOf": [
+                        {
+                            "description": "The event had no meaningful outcome",
+                            "type": "null"
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "The event succeeded",
+                                    "const": "Success"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "The event failed",
+                                    "const": "Failure"
+                                },
+                                {
+                                    "description": "Why the event failed",
+                                    "type": "object",
+                                    "properties": {
+                                        "causes": {
+                                            "description": "Available causes of failure",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "causes"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "event_type": {
+                    "description": "Type of event",
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "The server started running",
+                                    "const": "ServerStart"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "The server stopped running",
+                                    "const": "ServerStop"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "Verification began",
+                                    "const": "BeginVerify"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "file": {
+                                            "description": "Path of file being verified",
+                                            "type": "string"
+                                        },
+                                        "fn_name": {
+                                            "description": "Name of individual function being verified (if applicable)",
+                                            "anyOf": [
+                                                {
+                                                    "description": "Verification was initiated on the entire file",
+                                                    "type": "null"
+                                                },
+                                                {
+                                                    "description": "Verification was initiated on this function",
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        },
+                                        "fn_body": {
+                                            "description": "Body and specification of individual function being verified (if applicable)",
+                                            "anyOf": [
+                                                {
+                                                    "description": "Verification was initiated on the entire file",
+                                                    "type": "null"
+                                                },
+                                                {
+                                                    "description": "Verification was initiated on this function",
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "file",
+                                        "fn_name",
+                                        "fn_body"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "Verification ended",
+                                    "const": "EndVerify"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "file": {
+                                            "description": "Path of file being verified",
+                                            "type": "string"
+                                        },
+                                        "fn_name": {
+                                            "description": "Name of individual function being verified (if applicable)",
+                                            "anyOf": [
+                                                {
+                                                    "description": "Verification was of the entire file",
+                                                    "type": "null"
+                                                },
+                                                {
+                                                    "description": "Verification was of this function",
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "file",
+                                        "fn_name"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "A file was opened",
+                                    "const": "OpenFile"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "file": {
+                                            "description": "Path of opened file",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "file"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "A file was opened",
+                                    "const": "CloseFile"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "file": {
+                                            "description": "Path of closed file",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "file"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        },
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {
+                                    "description": "Configuration changed",
+                                    "const": "ChangeConfiguration"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "cfg": {
+                                            "type": "object",
+                                            "properties": {
+                                                "runOnSave": {
+                                                    "description": "Whether to run CN when a file is saved",
+                                                    "type": "boolean"
+                                                },
+                                                "telemetryDir": {
+                                                    "description": "Where to save telemetry files",
+                                                    "type": "string"
+                                                },
+                                                "userID": {
+                                                    "description": "User identifier",
+                                                    "anyOf": [
+                                                        {
+                                                            "description": "The user provided no identifier",
+                                                            "type": "null"
+                                                        },
+                                                        {
+                                                            "description": "The user provided this identifier",
+                                                            "type": "string"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "runOnSave",
+                                                "telemetryDir",
+                                                "userID"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "event_result",
+                "event_type"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "time",
+        "event_data"
+    ],
+    "additionalProperties": false
+}

--- a/docs/cn-lsp/2025-02-27-telemetry-schema.md
+++ b/docs/cn-lsp/2025-02-27-telemetry-schema.md
@@ -1,0 +1,77 @@
+# Introduction
+
+This document describes the layout of telemetry directories, and the schema of
+JSON-encoded telemetry events, in the CN language server (`cn-lsp`). This
+document is current as of today, 27 February 2025.
+
+# Directory Layout
+
+If a user provided `dir` as their telemetry directory, here's how that directory
+might be laid out:
+```
+dir
+├── profile.json
+├── session-X
+│   └── source-id
+│       ├── events.json
+│       └── source.json
+└── session-Y
+    └── source-id
+        ├── events.json
+        └── source.json
+```
+
+## `profile.json`
+
+Optional.
+
+Contains any profile information the user provides. If present, it should
+contain a single JSON object:
+```json
+{
+  "id": "<email-address>"
+}
+```
+
+
+## `session-{X,Y}`
+
+One or more.
+
+Each `session-X` directory contains telemetry associated with a single session.
+`X` here represents a session identifier. Currently, all session identifiers are
+calendar dates, encoded as `<year>-<month>-<day>`. (A session created today
+would be stored under `session-2025-2-27`.)
+
+
+## `source-id`
+
+One or more.
+
+A filename-friendly encoding of a particular source. (The full name is stored in
+this directory at `source.json`.)
+
+
+## `events.json`
+
+One exactly.
+
+A sequence of JSON-encoded telemetry events. Individual events are JSON objects
+that obey the schema specified [here](./2025-02-27-telemetry-schema.json). The
+"true" schema for these events is specified indirectly by the
+automatically-generated JSON serializers of the OCaml data structures specified
+in [`serverTelemetry.ml`](../../cn-lsp/lib/serverTelemetry.ml), but this schema
+should mirror that precisely.
+
+These events are stored sequentially in this file, separated by newlines. This
+means that, while each line contains a valid JSON object, these files themselves
+are *not*, strictly speaking, valid JSON. Consumers must split the file contents
+into lines and interpret each line as JSON.
+
+
+## `source.json`
+
+One exactly.
+
+The full name of the source of these events. For telemetry generated from
+`cn-lsp`, this source will be the literal `"cn-lsp-server"`.


### PR DESCRIPTION
This is a point-in-time description of the schema of the telemetry data that we expect to ship to Sandia. I've taken the liberty of writing this down as a machine-readable JSON schema. Let me know if we need something more human-readable - I should be able to generate something like HTML or Markdown from it.