### PR TITLE
Add gmp as a missing dependence

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ TBD: Links to project pages, more details as we discover them.
 
 Below are instructions for installing the VSCode integrations available for CN.
 Note that these integrations rely on
-[z3](https://github.com/Z3Prover/z3/releases) being installed and available on
-your `$PATH`; install it via your preferred package manager.
+[z3](https://github.com/Z3Prover/z3/releases) and [gmp](https://gmplib.org/) being installed and available on
+your `$PATH`; install it via your preferred package manager. For example, for MacOS we recommend running `brew install z3 gmp`.
 
 ### Installing a Release
 


### PR DESCRIPTION
Needed to make the plugin work.