### PR TITLE
opam: use latest CN version and its preferred Cerberus version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: ./cn-client
         run: |
           cp ../_opam/bin/cn-lsp-server cn-lsp-server
-          cp -r ../_opam/lib/cerberus/runtime cerb-runtime
+          cp -r ../_opam/lib/cerberus-lib/runtime cerb-runtime
           npm run dist
 
       - name: Upload artifacts

--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -155,7 +155,7 @@ async function newServerContext(
             }
 
             let serverPath = path.join(opamDir, "bin", "cn-lsp-server");
-            let cerbRuntime = path.join(opamDir, "lib", "cerberus", "runtime");
+            let cerbRuntime = path.join(opamDir, "lib", "cerberus-lib", "runtime");
 
             if (fs.existsSync(serverPath) && fs.existsSync(cerbRuntime)) {
                 return {

--- a/cn-lsp.opam
+++ b/cn-lsp.opam
@@ -8,9 +8,8 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "4.14.1" & < "6.0.0"}
   "base" {>= "v0.16.3" & < "v0.18"}
-  "cerberus" {= "d7d4e67"}
-  "cerberus-lib" {= "d7d4e67"}
-  "cn" {= "d7d4e67"}
+  "cerberus-lib" {= "ef237b3"}
+  "cn" {= "bf9f700"}
   "jsonrpc" {>= "1.17.0" & < "2.0.0"}
   "linol" {>= "0.6" & < "0.7"}
   "linol-lwt" {>= "0.6" & < "0.7"}
@@ -35,15 +34,11 @@ build: [
 ]
 pin-depends: [
   [
-    "cerberus.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
+    "cerberus-lib.ef237b3"
+    "git+https://github.com/rems-project/cerberus.git#ef237b3"
   ]
   [
-    "cerberus-lib.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
-  ]
-  [
-    "cn.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
+    "cn.bf9f700"
+    "git+https://github.com/rems-project/cn.git#bf9f700"
   ]
 ]

--- a/cn-lsp.opam.locked
+++ b/cn-lsp.opam.locked
@@ -15,10 +15,9 @@ depends: [
   "base-nnp" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "cerberus" {= "d7d4e67"}
-  "cerberus-lib" {= "d7d4e67"}
+  "cerberus-lib" {= "ef237b3"}
   "cmdliner" {= "1.3.0"}
-  "cn" {= "d7d4e67"}
+  "cn" {= "bf9f700"}
   "conf-findutils" {= "1"}
   "conf-gmp" {= "4"}
   "conf-pkg-config" {= "4"}
@@ -92,15 +91,8 @@ build: [
 ]
 pin-depends: [
   [
-    "cerberus.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
+    "cerberus-lib.ef237b3"
+    "git+https://github.com/rems-project/cerberus.git#ef237b3"
   ]
-  [
-    "cerberus-lib.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
-  ]
-  [
-    "cn.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
-  ]
+  ["cn.bf9f700" "git+https://github.com/rems-project/cn.git#bf9f700"]
 ]

--- a/cn-lsp.opam.template
+++ b/cn-lsp.opam.template
@@ -1,14 +1,10 @@
 pin-depends: [
   [
-    "cerberus.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
+    "cerberus-lib.ef237b3"
+    "git+https://github.com/rems-project/cerberus.git#ef237b3"
   ]
   [
-    "cerberus-lib.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
-  ]
-  [
-    "cn.d7d4e67"
-    "git+https://github.com/rems-project/cerberus.git#d7d4e67"
+    "cn.bf9f700"
+    "git+https://github.com/rems-project/cn.git#bf9f700"
   ]
 ]

--- a/cn-lsp/lib/range.ml
+++ b/cn-lsp/lib/range.ml
@@ -17,7 +17,7 @@ let ( |--| ) ((l1, c1) : int * int) ((l2, c2) : int * int) : t =
 ;;
 
 let of_cerb_loc (loc : Cerb_location.t) : t option =
-  match Cerb_location.to_cartesian loc with
+  match Cerb_location.to_cartesian_user loc with
   | None -> None
   | Some ((l1, c1), (l2, c2)) ->
     let start = Position.create ~line:l1 ~character:c1 in

--- a/dune-project
+++ b/dune-project
@@ -24,12 +24,10 @@
    (and
     (>= v0.16.3)
     (< v0.18)))
-  (cerberus
-   (= "d7d4e67"))
   (cerberus-lib
-   (= "d7d4e67"))
+   (= "ef237b3"))
   (cn
-   (= "d7d4e67"))
+   (= "bf9f700"))
   (jsonrpc
    (and
     (>= 1.17.0)


### PR DESCRIPTION
Also, remove `cerberus` dependency to mimic CN, which only depends on `cerberus-lib`.