### PR TITLE
client: use `CERB_INSTALL_PREFIX` to specify Cerberus runtime path

### DIFF
--- a/cn-client/package-lock.json
+++ b/cn-client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cn-client",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cn-client",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "dependencies": {
                 "vscode-languageclient": "^9.0.1"
             },

--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/GaloisInc/VERSE-Toolchain",
         "type": "git"
     },
-    "version": "0.1.1",
+    "version": "0.1.2",
     "engines": {
         "vscode": "^1.75.0"
     },

--- a/cn-client/src/extension.ts
+++ b/cn-client/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: vsc.ExtensionContext): Promise<void> {
 
     let env = process.env;
     if (serverContext.cerbRuntime !== undefined) {
-        env.CERB_RUNTIME = serverContext.cerbRuntime;
+        env.CERB_INSTALL_PREFIX = serverContext.cerbRuntime;
     } else {
         // TODO: we already tried to get ahold of the runtime when we generated
         // or retrieved in a server configuration, should we try again?


### PR DESCRIPTION
This variable was changed recently in Cerberus with https://github.com/rems-project/cerberus/commit/7d7271caa0d1c415f6c1088716627a0d0c29224d, and this change really should have been included in #185.