### PR TITLE
client: fix Cerberus runtime path specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
         working-directory: ./cn-client
         run: |
           cp ../_opam/bin/cn-lsp-server cn-lsp-server
-          cp -r ../_opam/lib/cerberus-lib/runtime cerb-runtime
+          mkdir -p fake-opam/lib/cerberus-lib
+          cp -r ../_opam/lib/cerberus-lib/runtime ./fake-opam/lib/cerberus-lib/runtime
           npm run dist
 
       - name: Upload artifacts

--- a/cn-client/.vscodeignore
+++ b/cn-client/.vscodeignore
@@ -6,4 +6,4 @@
 !package.json
 !README.md
 !cn-lsp-server
-!cerb-runtime
+!fake-opam

--- a/cn-client/package-lock.json
+++ b/cn-client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cn-client",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cn-client",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "dependencies": {
                 "vscode-languageclient": "^9.0.1"
             },

--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -6,7 +6,7 @@
         "url": "https://github.com/GaloisInc/VERSE-Toolchain",
         "type": "git"
     },
-    "version": "0.1.2",
+    "version": "0.1.3",
     "engines": {
         "vscode": "^1.75.0"
     },

--- a/cn-client/package.json
+++ b/cn-client/package.json
@@ -38,11 +38,6 @@
         "configuration": {
             "title": "CN",
             "properties": {
-                "CN.cerbRuntime": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Location of Cerberus runtime files"
-                },
                 "CN.reportDir": {
                     "type": "string",
                     "default": null,
@@ -52,6 +47,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Run CN whenever a file is saved"
+                },
+                "CN.runtimeDir": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Location of (`opam` or `opam`-like) directory containing Cerberus runtime files"
                 },
                 "CN.serverPath": {
                     "type": "string",


### PR DESCRIPTION
In #191, I misunderstood the change in semantics alluded to in https://github.com/rems-project/cerberus/commit/7d7271caa0d1c415f6c1088716627a0d0c29224d. `CERB_INSTALL_PREFIX` is not meant to refer to a location like `<opam-directory>/lib/cerberus-lib/runtime`, but rather to `<opam-directory>` itself, since Cerberus will unconditionally append `/lib/cerberus-lib/runtime` to whatever path is specified.

Accommodating this also means that our CI's bundling process needs to change. Since Cerberus expects to find its runtime files at a specific path, we need to mimic `opam`'s directory structure to replicate that path.