### PR TITLE
doc: rebuilding may require (re)installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ with `dune`:
 ```sh
 opam switch .
 eval $(opam env)
+opam install . --deps-only --locked -y
 dune build
 dune install
 ```


### PR DESCRIPTION
Fixes #190.

The suggestion in #190 doesn't include `--locked`, but I believe it is appropriate to include, since any newly-added dependencies this operation might pick up should be listed in the lockfile. (I believe CI ensures this.)